### PR TITLE
[FEAT] 장바구니 삭제 기능

### DIFF
--- a/src/main/java/com/futurenet/cotree/shoppingbasket/controller/ShoppingBasketController.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/controller/ShoppingBasketController.java
@@ -33,4 +33,11 @@ public class ShoppingBasketController {
         shoppingBasketService.saveBasketItem(memberId, itemId, quantity);
         return ResponseEntity.ok(new ApiResponse<>("SB100", null));
     }
+
+    @DeleteMapping("/{basketItemId}")
+    public ResponseEntity<?> deleteBasketItem(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable Long basketItemId) {
+        Long memberId = userPrincipal.getId();
+        shoppingBasketService.deleteBasketItem(memberId, basketItemId);
+        return ResponseEntity.ok(new ApiResponse<>("SB100", null));
+    }
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
@@ -12,4 +12,6 @@ public interface ShoppingBasketRepository {
     List<ShoppingBasketItemsResponse> getAllShoppingBasketItemsByMemberId(Long memberId);
     Long getBasketItemId(@Param("memberId") Long memberId, @Param("itemId") Long itemId);
     int updateBasketItemQuantity(@Param("basketItemId") Long basketItemId, @Param("quantity") Integer quantity);
-    int saveBasketItem(@Param("memberId") Long memberId, @Param("itemId") Long itemId, @Param("quantity") Integer quantity);}
+    int saveBasketItem(@Param("memberId") Long memberId, @Param("itemId") Long itemId, @Param("quantity") Integer quantity);
+    int deleteBasketItem(@Param("memberId") Long memberId, @Param("basketItemId") Long basketItemId);
+}

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketService.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketService.java
@@ -8,4 +8,5 @@ public interface ShoppingBasketService {
     void registerShoppingBasket(Long memberId);
     List<ShoppingBasketItemsResponse> getAllShoppingBasketItemsByMemberId(Long memberId);
     void saveBasketItem(Long memberId, Long itemId, Integer quantity);
+    void deleteBasketItem(Long memberId, Long basketItemId);
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketServiceImpl.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketServiceImpl.java
@@ -55,4 +55,18 @@ public class ShoppingBasketServiceImpl implements ShoppingBasketService {
             throw new ShoppingBasketException(ShoppingBasketErrorCode.INSERT_FAILED);
         }
     }
+
+    @Override
+    @Transactional
+    public void deleteBasketItem(Long memberId, Long basketItemId) {
+        if (basketItemId == null || basketItemId <= 0) {
+            throw new ShoppingBasketException(ShoppingBasketErrorCode.INVALID_BASKET_ITEM_ID);
+        }
+
+        int deleted = shoppingBasketRepository.deleteBasketItem(memberId, basketItemId);
+
+        if (deleted != 1) {
+            throw new ShoppingBasketException(ShoppingBasketErrorCode.BASKET_ITEM_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/exception/ShoppingBasketErrorCode.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/exception/ShoppingBasketErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ShoppingBasketErrorCode implements ErrorCode {
 
-    NOT_FOUND("SB001", HttpStatus.NOT_FOUND),
+    BASKET_NOT_FOUND("SB001", HttpStatus.NOT_FOUND),
     ITEM_NOT_FOUND("SB002", HttpStatus.NOT_FOUND),
     ITEM_ALREADY_EXISTS("SB003", HttpStatus.CONFLICT),
     INVALID_ITEM_ID("SB004", HttpStatus.BAD_REQUEST),
@@ -17,7 +17,9 @@ public enum ShoppingBasketErrorCode implements ErrorCode {
     ITEM_NOT_BELONG_TO_BASKET("SB006", HttpStatus.FORBIDDEN),
     INSERT_FAILED("SB007", HttpStatus.INTERNAL_SERVER_ERROR),
     UPDATE_FAILED("SB008", HttpStatus.INTERNAL_SERVER_ERROR),
-    DELETE_FAILED("SB009", HttpStatus.INTERNAL_SERVER_ERROR);
+    DELETE_FAILED("SB009", HttpStatus.INTERNAL_SERVER_ERROR),
+    BASKET_ITEM_NOT_FOUND("SB010", HttpStatus.NOT_FOUND),
+    INVALID_BASKET_ITEM_ID("SB011", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
+++ b/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
@@ -50,4 +50,12 @@
         FROM shopping_basket
         WHERE member_id = #{memberId}
     </insert>
+
+    <delete id="deleteBasketItem" parameterType="map">
+        DELETE FROM basket_item
+        WHERE shopping_basket_id = (
+            SELECT id FROM shopping_basket WHERE member_id = #{memberId}
+        )
+        AND id = #{basketItemId}
+    </delete>
 </mapper>


### PR DESCRIPTION
<!-- 제목 입력하기 -->
[FEAT] 장바구니 삭제 기능

## ✈️브랜치
 - feat/delete-shopping-baset-> main

## 🔗변경 사항
 - 장바구니 항목 삭제 기능 추가
 - basket_item.id 기반 DELETE API 구현
 - 삭제 실패 시 예외 응답 처리

## ✔️테스트
 - [x] 존재하는 항목 정상 삭제
 - [x] 잘못된 basketItemId로 요청 시 예외 발생 확인

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
