### PR TITLE
[FEAT] 장바구니 추가 시 수량체크 및 장바구니 담긴 아이템 개수 조회

### DIFF
--- a/src/main/java/com/futurenet/cotree/shoppingbasket/controller/ShoppingBasketController.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/controller/ShoppingBasketController.java
@@ -3,6 +3,7 @@ package com.futurenet.cotree.shoppingbasket.controller;
 import com.futurenet.cotree.auth.security.dto.UserPrincipal;
 import com.futurenet.cotree.global.dto.response.ApiResponse;
 import com.futurenet.cotree.shoppingbasket.dto.request.ShoppingBasketAddRequest;
+import com.futurenet.cotree.shoppingbasket.dto.response.ShoppingBasketCountResponse;
 import com.futurenet.cotree.shoppingbasket.dto.response.ShoppingBasketItemsResponse;
 import com.futurenet.cotree.shoppingbasket.service.ShoppingBasketService;
 import jakarta.validation.Valid;
@@ -40,5 +41,12 @@ public class ShoppingBasketController {
         Long memberId = userPrincipal.getId();
         shoppingBasketService.deleteBasketItem(memberId, basketItemId);
         return ResponseEntity.ok(new ApiResponse<>("SB100", null));
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<?> getBasketItemCount(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        int count = (userPrincipal == null) ? 0 : shoppingBasketService.countBasketItems(userPrincipal.getId());
+        ShoppingBasketCountResponse shoppingBasketCountResponse = new ShoppingBasketCountResponse(count);
+        return ResponseEntity.ok(new ApiResponse<>("SB101", shoppingBasketCountResponse));
     }
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/dto/response/ShoppingBasketCountResponse.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/dto/response/ShoppingBasketCountResponse.java
@@ -1,0 +1,12 @@
+package com.futurenet.cotree.shoppingbasket.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShoppingBasketCountResponse {
+    private int count;
+}

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
@@ -15,4 +15,5 @@ public interface ShoppingBasketRepository {
     int saveBasketItem(@Param("memberId") Long memberId, @Param("itemId") Long itemId, @Param("quantity") Integer quantity);
     int deleteBasketItem(@Param("memberId") Long memberId, @Param("basketItemId") Long basketItemId);
     int getBasketItemQuantity(@Param("memberId") Long memberId, @Param("itemId") Long itemId);
+    int countBasketItems(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
@@ -16,4 +16,6 @@ public interface ShoppingBasketRepository {
     int deleteBasketItem(@Param("memberId") Long memberId, @Param("basketItemId") Long basketItemId);
     int getBasketItemQuantity(@Param("memberId") Long memberId, @Param("itemId") Long itemId);
     int countBasketItems(@Param("memberId") Long memberId);
+    int deleteBasketItemsByMemberIdAndItemIds(@Param("memberId") Long memberId, @Param("itemIds") List<Long> itemIds);
+
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/repository/ShoppingBasketRepository.java
@@ -14,4 +14,5 @@ public interface ShoppingBasketRepository {
     int updateBasketItemQuantity(@Param("basketItemId") Long basketItemId, @Param("quantity") Integer quantity);
     int saveBasketItem(@Param("memberId") Long memberId, @Param("itemId") Long itemId, @Param("quantity") Integer quantity);
     int deleteBasketItem(@Param("memberId") Long memberId, @Param("basketItemId") Long basketItemId);
+    int getBasketItemQuantity(@Param("memberId") Long memberId, @Param("itemId") Long itemId);
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketService.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketService.java
@@ -10,4 +10,5 @@ public interface ShoppingBasketService {
     void saveBasketItem(Long memberId, Long itemId, Integer quantity);
     void deleteBasketItem(Long memberId, Long basketItemId);
     int countBasketItems(Long memberId);
+    void deleteBasketItemsByMemberIdAndItemIds(Long memberId, List<Long> itemIds);
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketService.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketService.java
@@ -9,4 +9,5 @@ public interface ShoppingBasketService {
     List<ShoppingBasketItemsResponse> getAllShoppingBasketItemsByMemberId(Long memberId);
     void saveBasketItem(Long memberId, Long itemId, Integer quantity);
     void deleteBasketItem(Long memberId, Long basketItemId);
+    int countBasketItems(Long memberId);
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketServiceImpl.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketServiceImpl.java
@@ -77,4 +77,9 @@ public class ShoppingBasketServiceImpl implements ShoppingBasketService {
             throw new ShoppingBasketException(ShoppingBasketErrorCode.BASKET_ITEM_NOT_FOUND);
         }
     }
+
+    @Override
+    public int countBasketItems(Long memberId) {
+        return shoppingBasketRepository.countBasketItems(memberId);
+    }
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketServiceImpl.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/ShoppingBasketServiceImpl.java
@@ -82,4 +82,17 @@ public class ShoppingBasketServiceImpl implements ShoppingBasketService {
     public int countBasketItems(Long memberId) {
         return shoppingBasketRepository.countBasketItems(memberId);
     }
+
+    @Override
+    @Transactional
+    public void deleteBasketItemsByMemberIdAndItemIds(Long memberId, List<Long> itemIds) {
+        if (itemIds == null || itemIds.isEmpty()) {
+            throw new ShoppingBasketException(ShoppingBasketErrorCode.INVALID_BASKET_ITEM_ID);
+        }
+
+        int deleted = shoppingBasketRepository.deleteBasketItemsByMemberIdAndItemIds(memberId, itemIds);
+        if (deleted == 0) {
+            throw new ShoppingBasketException(ShoppingBasketErrorCode.DELETE_FAILED);
+        }
+    }
 }

--- a/src/main/java/com/futurenet/cotree/shoppingbasket/service/exception/ShoppingBasketErrorCode.java
+++ b/src/main/java/com/futurenet/cotree/shoppingbasket/service/exception/ShoppingBasketErrorCode.java
@@ -19,7 +19,8 @@ public enum ShoppingBasketErrorCode implements ErrorCode {
     UPDATE_FAILED("SB008", HttpStatus.INTERNAL_SERVER_ERROR),
     DELETE_FAILED("SB009", HttpStatus.INTERNAL_SERVER_ERROR),
     BASKET_ITEM_NOT_FOUND("SB010", HttpStatus.NOT_FOUND),
-    INVALID_BASKET_ITEM_ID("SB011", HttpStatus.BAD_REQUEST);
+    INVALID_BASKET_ITEM_ID("SB011", HttpStatus.BAD_REQUEST),
+    QUANTITY_EXCEEDS_STOCK("SB012", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
+++ b/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
@@ -13,8 +13,8 @@
     <select id="getAllShoppingBasketItemsByMemberId" parameterType="Long" resultType="com.futurenet.cotree.shoppingbasket.dto.response.ShoppingBasketItemsResponse">
         SELECT
             bi.id AS basket_item_id,
-            bi.quantity,
             i.id AS item_id,
+            bi.quantity,
             i.name as item_name,
             i.price,
             i.discount,
@@ -58,4 +58,12 @@
         )
         AND id = #{basketItemId}
     </delete>
+
+    <select id="getBasketItemQuantity" resultType="int" parameterType="map">
+        SELECT bi.quantity
+        FROM basket_item bi
+        JOIN shopping_basket sb ON bi.shopping_basket_id = sb.id
+        WHERE sb.member_id = #{memberId}
+        AND bi.item_id = #{itemId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
+++ b/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
@@ -75,4 +75,15 @@
         JOIN shopping_basket sb ON bi.shopping_basket_id = sb.id
         WHERE sb.member_id = #{memberId}
     </select>
+
+    <delete id="deleteBasketItemsByMemberIdAndItemIds" parameterType="map">
+        DELETE FROM basket_item
+        WHERE shopping_basket_id = (
+        SELECT id FROM shopping_basket WHERE member_id = #{memberId}
+        )
+        AND item_id IN
+        <foreach item="itemId" collection="itemIds" open="(" separator="," close=")">
+            #{itemId}
+        </foreach>
+    </delete>
 </mapper>

--- a/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
+++ b/src/main/resources/mapper/shoppingbasket/ShoppingBasketMapper.xml
@@ -23,7 +23,9 @@
             b.name AS brand_name
         FROM
             shopping_basket sb
-            JOIN basket_item bi ON sb.id = bi.shopping_basket_id
+            JOIN basket_item
+
+        bi ON sb.id = bi.shopping_basket_id
             JOIN item i ON bi.item_id = i.id
             LEFT JOIN brand b ON i.brand_id = b.id
         WHERE sb.member_id = #{memberId}
@@ -65,5 +67,12 @@
         JOIN shopping_basket sb ON bi.shopping_basket_id = sb.id
         WHERE sb.member_id = #{memberId}
         AND bi.item_id = #{itemId}
+    </select>
+
+    <select id="countBasketItems" resultType="int">
+        SELECT COUNT(*) as count
+        FROM basket_item bi
+        JOIN shopping_basket sb ON bi.shopping_basket_id = sb.id
+        WHERE sb.member_id = #{memberId}
     </select>
 </mapper>


### PR DESCRIPTION
<!-- 제목 입력하기 -->
[FEAT] 장바구니 추가 시 수량체크 및 장바구니 담긴 아이템 개수 조회

<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
 - fix/shopping-basket -> main

## 🔗변경 사항
#51 

## ✔️테스트
- [x] 기존 장바구니에 동일 상품이 있는 경우 현재 수량 + 추가 수량 > 재고 조건을 검증
- [x] 장바구니에 담긴 아이템 개수 조회 확인

<!-- 주석 부분 지우지 말고 작성 -->
close #51
