### PR TITLE
[FIX] 로그인 하지 않은 유저 401 -> 204반환

### DIFF
--- a/src/main/java/com/futurenet/cotree/tree/controller/TreeController.java
+++ b/src/main/java/com/futurenet/cotree/tree/controller/TreeController.java
@@ -42,6 +42,7 @@ public class TreeController {
     @GetMapping("/summary")
     public ResponseEntity<?> getTreeSummary(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         Long memberId = (userPrincipal != null) ? userPrincipal.getId() : null;
+        if (memberId == null) return ResponseEntity.noContent().build();
         MyTreeSummaryResponse myTreeSummaryResponse = treeService.getMyTreeSummary(memberId);
         return ResponseEntity.ok(new ApiResponse<>("TR100", myTreeSummaryResponse));
     }

--- a/src/main/java/com/futurenet/cotree/tree/service/TreeServiceImpl.java
+++ b/src/main/java/com/futurenet/cotree/tree/service/TreeServiceImpl.java
@@ -94,9 +94,6 @@ public class TreeServiceImpl implements TreeService {
 
     @Override
     public MyTreeSummaryResponse getMyTreeSummary(Long memberId) {
-        if(memberId==null) {
-            throw new TreeException(TreeErrorCode.UNAUTHORIZED_SUMMARY_REQUEST);
-        }
         LocalDate today = LocalDate.now();
         LocalDate start = today.withDayOfMonth(1);
         LocalDate end = today.withDayOfMonth(today.lengthOfMonth());


### PR DESCRIPTION
<!-- 제목 입력하기 -->
[FIX] 로그인 하지 않은 유저 401 -> 204반환


<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
 - fix/tree-summary-throw

## 🔗변경 사항
 - 로그인 하지 않은 유저가 나무 요약 정보 가져올 때  401 -> 204 반환

## ✔️테스트
 - 로그인 하지 않은 유저 접속 시 401에러 사라지는걸 확인

<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
