### PR TITLE
[REFACTOR] 재고 차감 로직 비동기 처리로 개선 

### DIFF
--- a/src/main/java/com/futurenet/cotree/global/config/AppConfig.java
+++ b/src/main/java/com/futurenet/cotree/global/config/AppConfig.java
@@ -1,0 +1,23 @@
+package com.futurenet.cotree.global.config;
+
+import com.futurenet.cotree.order.dto.request.QuantityDecreaseRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Configuration
+public class AppConfig {
+    /**
+     * 재고 차감 요청을 담을 인메모리 큐를 스프링 빈으로 등록.
+     * 이 큐는 BlockingQueue 인터페이스를 구현하며, LinkedBlockingQueue는 내부적으로
+     * 스레드 안전하게 동작하므로 여러 스레드에서 동시에 접근해도 문제가 없음
+     *
+     * @return BlockingQueue<QuantityDecreaseRequest> 타입의 인메모리 큐 인스턴스
+     */
+    @Bean
+    public BlockingQueue<QuantityDecreaseRequest> quantityDecreaseQueue() {
+        return new LinkedBlockingQueue<>();
+    }
+}

--- a/src/main/java/com/futurenet/cotree/item/repository/ItemRepository.java
+++ b/src/main/java/com/futurenet/cotree/item/repository/ItemRepository.java
@@ -23,4 +23,10 @@ public interface ItemRepository {
     List<Long> lockItemsInOrder(@Param("ids") List<Long> ids);
     List<ItemPriceAndIsEcoResponse> getItemPriceAndIsEcoByIds(@Param("ids") List<Long> ids);
     List<Item> getEventItems();
+
+    Item getItem(@Param("id") Long id);
+    int decreaseQuantity(@Param("id") Long id, @Param("quantity") int quantity);
+
+
+
 }

--- a/src/main/java/com/futurenet/cotree/item/service/ItemService.java
+++ b/src/main/java/com/futurenet/cotree/item/service/ItemService.java
@@ -15,4 +15,6 @@ public interface ItemService {
     List<ItemResponse> getTodayItems();
     void bulkDecreaseStock(List<OrderItemRegisterRequest> orderItemRegisterRequests);
     void decreaseStock(List<OrderItemRegisterRequest> orderItemRegisterRequests);
+    void decreaseQuantity(Long itemId, int quantity);
+
 }

--- a/src/main/java/com/futurenet/cotree/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/futurenet/cotree/item/service/ItemServiceImpl.java
@@ -132,4 +132,24 @@ public class ItemServiceImpl implements ItemService {
         }
         eventPublisher.publishEvent(event);
     }
+
+    @Override
+    public void decreaseQuantity(Long itemId, int quantity) {
+        Item item = itemRepository.getItem(itemId);
+
+        if (item == null) {
+            throw new ItemException(ItemErrorCode.ITEM_NOT_FOUND);
+        }
+
+        if (item.getQuantity() < quantity) {
+            throw new ItemException(ItemErrorCode.ITEM_QUANTITY_LACK);
+        }
+
+        int updatedRows = itemRepository.decreaseQuantity(itemId, quantity);
+
+        if (updatedRows == 0) {
+            throw new ItemException(ItemErrorCode.ITEM_QUANTITY_LACK);
+        }
+
+    }
 }

--- a/src/main/java/com/futurenet/cotree/item/service/QuantityDecreaseWorkerService.java
+++ b/src/main/java/com/futurenet/cotree/item/service/QuantityDecreaseWorkerService.java
@@ -1,0 +1,71 @@
+package com.futurenet.cotree.item.service;
+
+import com.futurenet.cotree.order.dto.request.QuantityDecreaseRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuantityDecreaseWorkerService implements ApplicationRunner, DisposableBean {
+    private final BlockingQueue<QuantityDecreaseRequest> quantityDecreaseQueue;
+    private final ItemService itemService;
+    private ExecutorService executorService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            log.info("재고 차감 워커 스레드 시작.");
+            while (!Thread.currentThread().isInterrupted()) {
+                QuantityDecreaseRequest request = null;
+                try {
+                    request = quantityDecreaseQueue.take();
+                    log.info("재고 차감 요청 처리 시작: itemId={}, quantity={}", request.getItemId(), request.getQuantity());
+
+                    itemService.decreaseQuantity(request.getItemId(), request.getQuantity());
+                    log.info("재고 차감 성공: itemId={}, quantity={}", request.getItemId(), request.getQuantity());
+
+                    // TODO: 재고 차감 성공 후 필요한 추가 로직
+
+                } catch (InterruptedException e) {
+                    log.warn("재고 차감 워커 스레드 인터럽트 발생, 종료합니다.");
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (Exception e) {
+                    String itemId = (request != null) ? String.valueOf(request.getItemId()) : "N/A";
+                    String quantity = (request != null) ? String.valueOf(request.getQuantity()) : "N/A";
+                    log.error("재고 차감 실패: itemId={}, quantity={}, 에러: {}", itemId, quantity, e.getMessage(), e);
+                    // TODO: 재고 차감 실패 시 보상 트랜잭션 또는 재시도 로직
+                }
+            }
+        });
+    }
+    @Override
+    public void destroy() {
+        if (executorService != null) {
+            executorService.shutdown();
+            log.info("재고 차감 워커 스레드 풀 종료 요청됨.");
+            try {
+                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    executorService.shutdownNow();
+                    log.warn("재고 차감 워커 스레드 강제 종료됨: 아직 처리되지 않은 요청이 있을 수 있습니다.");
+                }
+            } catch (InterruptedException e) {
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt();
+                log.error("재고 차감 워커 스레드 종료 중 인터럽트 발생.", e);
+            }
+            log.info("재고 차감 워커 스레드 종료 완료.");
+        }
+    }
+}

--- a/src/main/java/com/futurenet/cotree/item/service/exception/ItemErrorCode.java
+++ b/src/main/java/com/futurenet/cotree/item/service/exception/ItemErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ItemErrorCode implements ErrorCode {
 
-    ITEM_QUANTITY_LACK("IT000", HttpStatus.BAD_REQUEST);
+    ITEM_QUANTITY_LACK("IT000", HttpStatus.BAD_REQUEST),
+    ITEM_NOT_FOUND("IT001", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/futurenet/cotree/order/controller/OrderController.java
+++ b/src/main/java/com/futurenet/cotree/order/controller/OrderController.java
@@ -42,4 +42,11 @@ public class OrderController {
         OrderDetailResponse result = orderFacadeService.getOrderDetail(orderNumber, userPrincipal.getId());
         return ResponseEntity.ok(new ApiResponse<>("OR102", result));
     }
+
+    @PostMapping("/async")
+    public ResponseEntity<?> createOrders(@Valid @RequestBody OrderRequest orderRequest,
+                                         @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        String orderNumber = orderFacadeService.registerOrders(orderRequest, userPrincipal.getId());
+        return ResponseEntity.ok(new ApiResponse<>("OR100", orderNumber));
+    }
 }

--- a/src/main/java/com/futurenet/cotree/order/dto/request/QuantityDecreaseRequest.java
+++ b/src/main/java/com/futurenet/cotree/order/dto/request/QuantityDecreaseRequest.java
@@ -1,0 +1,15 @@
+package com.futurenet.cotree.order.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuantityDecreaseRequest {
+    private Long itemId;
+    private int quantity;
+}

--- a/src/main/java/com/futurenet/cotree/order/service/OrderFacadeService.java
+++ b/src/main/java/com/futurenet/cotree/order/service/OrderFacadeService.java
@@ -10,4 +10,5 @@ public interface OrderFacadeService {
     String registerOrder(OrderRequest orderRequest, Long memberId);
     List<OrderResponse> getOrdersByMember(Long memberId, String status, int page);
     OrderDetailResponse getOrderDetail(String orderNumber, Long memberId);
+    String registerOrders(OrderRequest orderRequest, Long memberId);
 }

--- a/src/main/java/com/futurenet/cotree/order/service/exception/OrderErrorCode.java
+++ b/src/main/java/com/futurenet/cotree/order/service/exception/OrderErrorCode.java
@@ -14,7 +14,8 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_STATUS_UPDATE_FAIL("OR002", HttpStatus.BAD_REQUEST),
     ORDER_NOT_FOUND("OR003", HttpStatus.BAD_REQUEST),
     ORDER_ITEM_NOT_FOUND("OR004", HttpStatus.BAD_REQUEST),
-    ORDER_ACCESS_DENIED("OR005", HttpStatus.FORBIDDEN);
+    ORDER_ACCESS_DENIED("OR005", HttpStatus.FORBIDDEN),
+    ORDER_PROCESSING_FAILED("OR006", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/resources/mapper/item/ItemMapper.xml
+++ b/src/main/resources/mapper/item/ItemMapper.xml
@@ -142,4 +142,18 @@
     </select>
 
 
+    <select id="getItem" resultType="com.futurenet.cotree.item.domain.Item">
+        SELECT id,quantity
+        FROM item
+        WHERE id=#{id}
+            FOR UPDATE
+    </select>
+
+
+    <update id="decreaseQuantity">
+        UPDATE item
+        SET quantity = quantity - #{quantity}
+        WHERE id = #{id}
+          AND quantity >= #{quantity}
+    </update>
 </mapper>


### PR DESCRIPTION

<!-- 제목 입력하기 -->
- [REFACTOR] 성능 병목을 유발하던 동기 방식의 재고 처리 로직을 인메모리 큐를 이용한 비동기 방식으로 리팩토링


<!-- 주석 부분 모두 지우고 작성 -->
## ✈️브랜치
 - feat/async-order -> main

## 🔗변경 사항


## ✔️테스트


<!-- 주석 부분 지우지 말고 작성 -->
<!--  close #00 -->
